### PR TITLE
ステップ10: Railsのタイムゾーンを設定しましょう

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -11,6 +11,10 @@ module ManyoTodoApp
     # Initialize configuration defaults for originally generated Rails version.
     config.load_defaults 5.1
     config.i18n.default_locale = :ja
+    # 表示時のタイムゾーンをJSTに変更
+    config.time_zone = 'Tokyo'
+    # DB保存時のタイムゾーンをJSTに変更
+    config.active_record.default_timezone = :local
     # Settings in config/environments/* take precedence over those specified here.
     # Application configuration should go into files in config/initializers
     # -- all .rb files in that directory are automatically loaded.


### PR DESCRIPTION
```
[2] pry(main)> Time.zone.now
=> Fri, 09 Mar 2018 17:18:46 JST +09:00
[5] pry(main)> Time.zone
=> #<ActiveSupport::TimeZone:0x007ffdeaa1d250 @name="Tokyo", @tzinfo=#<TZInfo::DataTimezone: Asia/Tokyo>, @utc_offset=nil>
```

> Railsのタイムゾーンを日本（東京）に設定しましょう

- タイムゾーンを日本（東京）に設定

●確認
- TimeがJST、zoneがtokyoになっていることを確認