### PR TITLE
ステップ11: タスク一覧を作成日時の順番で並び替えましょう

### DIFF
--- a/app/controllers/tasks_controller.rb
+++ b/app/controllers/tasks_controller.rb
@@ -6,7 +6,7 @@ before_action :set_task, only:[:update, :destroy]
   def index
     # 暫定対処
     @task = Task.new
-    @tasks = Task.all
+    @tasks = Task.all.order(created_at: :desc)
   end
 
   def create

--- a/spec/controllers/tasks_controller.rb
+++ b/spec/controllers/tasks_controller.rb
@@ -13,6 +13,19 @@ describe TasksController do
     end
   end
 
+  describe "order_by_created_at_desc" do
+    context "日付が新しい順に並ぶかどうか" do
+      before(:each) do
+        create(:task, id: 1, content: "tast 1", created_at: Time.current)
+        create(:task, id: 2, content: "task 2", created_at: Time.current - 1.days)
+      end
+
+      example "taskをcreated_atの降順で並び替える" do
+        expect(Task.all.order(created_at: :desc).map(&:id)).to eq [1, 2]
+      end
+    end
+  end
+
   describe 'POST #create' do
     it "success to save" do
       task = build(:task)


### PR DESCRIPTION
```
Running via Spring preloader in process 14349
......

Finished in 0.10458 seconds (files took 0.42999 seconds to load)
6 examples, 0 failures
```

> 現在IDの順で並んでいますが、これを作成日時の降順で並び替えてみましょう
並び替えがうまく行っていることをfeature specで書いてみましょう

- 一覧画面に.order(created_at: :desc)を追加
- ソートのテストを追加